### PR TITLE
perf(query): streaming KB, IVF parallelization, and prompt optimizations

### DIFF
--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	AppName    = "Eulix"
-	AppVersion = "v0.6.8"
+	AppVersion = "v0.6.9"
 )
 
 var (

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -489,66 +490,84 @@ func (c *Client) BuildFullPrompt(context *types.ContextWindow, userQuery string,
 	return sb.String()
 }
 
+// buildPrompt builds only the context payload — no instruction boilerplate.
+// Instructions belong in buildSystemPrompt() which is passed as the system role.
 func (c *Client) buildPrompt(context *types.ContextWindow, userQuery string) string {
 	var sb strings.Builder
 
-	// CONTEXT INVENTORY HEADER
-	sb.WriteString("CONTEXT INVENTORY\n")
-
-	// Separate chunks into source code vs metadata-only for clarity
-	var sourceChunks, metadataChunks []types.ContextChunk
+	// Separate source vs metadata chunks
+	var srcChunks, metaChunks []types.ContextChunk
 	for _, chunk := range context.Chunks {
 		if strings.TrimSpace(chunk.Content) != "" && !strings.HasPrefix(chunk.Content, "[METADATA]") {
-			sourceChunks = append(sourceChunks, chunk)
+			srcChunks = append(srcChunks, chunk)
 		} else {
-			metadataChunks = append(metadataChunks, chunk)
+			metaChunks = append(metaChunks, chunk)
 		}
 	}
 
-	// Summary statistics
-	sb.WriteString(fmt.Sprintf("Available evidence:\n"))
-	sb.WriteString(fmt.Sprintf("  • Source code chunks : %d (files with actual implementation)\n", len(sourceChunks)))
-	sb.WriteString(fmt.Sprintf("  • Metadata chunks    : %d (signatures, call edges, structural info)\n", len(metadataChunks)))
-	sb.WriteString(fmt.Sprintf("  • Total tokens       : %d\n", context.TotalTokens))
-	sb.WriteString(fmt.Sprintf("  • Files covered      : %d\n\n", len(context.Sources)))
+	// Compact inventory header — just counts, no per-token explanation
+	sb.WriteString(fmt.Sprintf(
+		"Context: %d source chunks, %d metadata, %d tokens across %d files\n\n",
+		len(srcChunks), len(metaChunks), context.TotalTokens, len(context.Sources),
+	))
 
-	// Usage guidance
-	sb.WriteString("HOW TO USE THIS CONTEXT:\n")
-	sb.WriteString("  • Source code chunks = ground truth. Cite them directly.\n")
-	sb.WriteString("  • Metadata chunks    = structural hints only. Do NOT invent implementation.\n")
-	sb.WriteString("  • If a symbol appears only in metadata, state: 'signature only — lines X-Y of file Z'\n")
-	sb.WriteString("  • Never fabricate function bodies, variable values, or logic you cannot see.\n\n")
-
-	// SOURCE CODE CHUNKS
-	if len(sourceChunks) > 0 {
-		sb.WriteString("─── SOURCE CODE (ground truth) ───\n\n")
-		for i, chunk := range sourceChunks {
-			sb.WriteString(fmt.Sprintf("[CHUNK %d] %s (Lines %d-%d) — relevance %.2f\n",
+	if len(srcChunks) > 0 {
+		sb.WriteString("── SOURCE ──\n\n")
+		for i, chunk := range srcChunks {
+			sb.WriteString(fmt.Sprintf("[%d] %s:%d-%d (score %.2f)\n",
 				i+1, chunk.File, chunk.StartLine, chunk.EndLine, chunk.Importance))
-			sb.WriteString(strings.Repeat("-", 60) + "\n")
 			sb.WriteString(chunk.Content)
 			sb.WriteString("\n\n")
 		}
 	}
 
-	// METADATA CHUNKS
-	if len(metadataChunks) > 0 {
-		sb.WriteString("─── METADATA (structural hints) ───\n\n")
-		for i, chunk := range metadataChunks {
-			sb.WriteString(fmt.Sprintf("[META %d] %s (Lines %d-%d) — relevance %.2f\n",
-				i+1, chunk.File, chunk.StartLine, chunk.EndLine, chunk.Importance))
-			sb.WriteString(strings.Repeat("-", 60) + "\n")
+	if len(metaChunks) > 0 {
+		sb.WriteString("── METADATA ──\n\n")
+		for i, chunk := range metaChunks {
+			sb.WriteString(fmt.Sprintf("[M%d] %s:%d-%d\n",
+				i+1, chunk.File, chunk.StartLine, chunk.EndLine))
 			sb.WriteString(chunk.Content)
 			sb.WriteString("\n\n")
 		}
 	}
 
-	//  EVIDENCE RULES
-	sb.WriteString("EVIDENCE RULES:\n")
-	sb.WriteString("  1. Cite file + line range for every claim.\n")
-	sb.WriteString("  2. Distinguish: \"Source shows…\" vs \"Signature implies…\" vs \"Metadata indicates…\"\n")
-	sb.WriteString("  3. Write \"Not visible in context\" rather than guessing.\n")
-	sb.WriteString("  4. Never invent function bodies or logic you cannot see.\n\n")
+	sb.WriteString("QUERY\n")
+	sb.WriteString(userQuery)
+	sb.WriteString("\n")
 
 	return sb.String()
+}
+
+// fillResidualBudget does a second bin-packing pass over skipped chunks,
+// fitting any that are small enough to fill the remaining token budget.
+// Call this after the primary greedy hydration loop.
+//
+// skipped: chunks that didn't fit in order (index → token cost)
+// remaining: tokens left after the greedy pass
+// addChunk: callback that appends the chunk content and returns new remaining
+func fillResidualBudget(
+	skipped []types.ContextChunk,
+	remaining int,
+	addChunk func(chunk types.ContextChunk) int, // returns new remaining
+) int {
+	if remaining <= 0 || len(skipped) == 0 {
+		return remaining
+	}
+
+	// Sort skipped by token cost ascending — fit smallest first
+	sorted := make([]types.ContextChunk, len(skipped))
+	copy(sorted, skipped)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Tokens < sorted[j].Tokens
+	})
+
+	for _, chunk := range sorted {
+		if remaining <= 0 {
+			break
+		}
+		if chunk.Tokens <= remaining {
+			remaining = addChunk(chunk)
+		}
+	}
+	return remaining
 }

--- a/internal/query/contextTypes.go
+++ b/internal/query/contextTypes.go
@@ -158,6 +158,7 @@ type Chunk struct {
 	Content    string
 	Tokens     int
 	Symbols    []string
+	ClassName  string
 	Name       string
 	Importance float64
 }
@@ -321,4 +322,36 @@ type VectorStoreHeader struct {
 	Version   uint32
 	Count     uint64
 	Dimension uint32
+}
+
+// Lightweight closure-capture types
+// These hold only the fields buildChunkFromKBFunction/Class actually read,
+// avoiding keeping the full types.KBFunction/KBClass alive per closure.
+
+type fnParts struct {
+	name      string
+	signature string
+	docstring string
+	lineStart int
+	lineEnd   int
+	calls     []callPart // only Callee + Line used
+}
+
+type callPart struct {
+	callee string
+	line   int
+}
+
+type classParts struct {
+	name      string
+	docstring string
+	lineStart int
+	lineEnd   int
+	methods   []methodPart // only Name + LineStart + LineEnd used
+}
+
+type methodPart struct {
+	name      string
+	lineStart int
+	lineEnd   int
 }

--- a/internal/query/context_builder.go
+++ b/internal/query/context_builder.go
@@ -75,17 +75,16 @@ func ContextWindowCreator(eulixDir string, cfg *config.Config, llmClient *llm.Cl
 	}
 	cb.debugLog.Log("Initializing ContextBuilder with source root: %s", sourceRoot)
 
-	// eulixBinaryPath := filepath.Join(eulixDir, "..", "eulix_embed")
 	queryEmbedder, err := embeddings.VectorWeaver(cfg.Embeddings.Model)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize embedder: %w", err)
 	}
 	cb.queryEmbedder = queryEmbedder
-	// Load chunks from kb.json + kb_index.json (replaces embeddings.json)
+
 	if err := cb.loadChunksFromKB(); err != nil {
 		return nil, fmt.Errorf("failed to load chunks from KB: %w", err)
 	}
-	// Load raw float32 embeddings from embeddings.bin
+
 	if err := cb.loadEmbeddings(); err != nil {
 		cb.debugLog.Log("Embeddings not loaded: %v", err)
 		cb.hasEmbeddings = false
@@ -93,7 +92,7 @@ func ContextWindowCreator(eulixDir string, cfg *config.Config, llmClient *llm.Cl
 		cb.hasEmbeddings = true
 		cb.debugLog.Log("Loaded %d embeddings", len(cb.embeddings))
 	}
-	// Load id→embedding-index map from vectors.bin
+
 	if err := cb.loadVectorMap(); err != nil {
 		cb.debugLog.Log("Vector map not loaded: %v", err)
 		cb.vectorMap = make(map[string]int)
@@ -101,9 +100,10 @@ func ContextWindowCreator(eulixDir string, cfg *config.Config, llmClient *llm.Cl
 		cb.debugLog.Log("Loaded %d vector mappings", len(cb.vectorMap))
 	}
 
-	cb.loadCallGraph()
-	cb.hasKB = true
+	// Single unified call graph load — runs after chunks are ready
+	cb.loadAndIndexCallGraph()
 
+	cb.hasKB = true
 	cb.debugLog.Log("ContextBuilder initialized successfully")
 	return cb, nil
 }
@@ -130,6 +130,7 @@ func (cb *ContextBuilder) buildContextInternal(query string, maxLinesDefault int
 	trace := &DebugTrace{Query: query}
 	explicitAnchor := extractExplicitAnchors(query)
 	gate := buildPathGate(explicitAnchor)
+
 	cb.debugLog.Log("\n=== NEW QUERY ===")
 	cb.debugLog.Log("Query: %s", query)
 
@@ -137,6 +138,7 @@ func (cb *ContextBuilder) buildContextInternal(query string, maxLinesDefault int
 	trace.Intent = intent
 	cb.debugLog.Log("Intent: %d (specificity: %.2f, confidence: %.2f)",
 		intent.Type, intent.Specificity, intent.Confidence)
+
 	var qEmb []float32
 	skipSemantic := intent.Type == IntentCallers ||
 		intent.Type == IntentCallees ||
@@ -148,11 +150,12 @@ func (cb *ContextBuilder) buildContextInternal(query string, maxLinesDefault int
 			trace.Warnings = append(trace.Warnings, "query embedding failed: "+err.Error())
 		}
 	}
+
 	budget := cb.allocateBudget(query, intent)
 	trace.Budget = budget
 	cb.debugLog.Log("Budget: %d tokens for context (total: %d)",
 		budget.ContextBudget, budget.MaxTokens)
-	// Always anchor on the queried symbol(s) first
+
 	anchors := cb.exactSymbolSearch(query)
 	if len(anchors) > 2 {
 		anchors = anchors[:2]
@@ -162,7 +165,7 @@ func (cb *ContextBuilder) buildContextInternal(query string, maxLinesDefault int
 		anchorFiles[a.File] = true
 	}
 	cb.debugLog.Log("Found %d exact anchors", len(anchors))
-	// For caller/callee intents do direct call-site scan
+
 	var callSiteResults []ScoredChunk
 	if intent.Type == IntentCallers || intent.Type == IntentCallees {
 		callSiteResults = cb.findCallSites(query, intent)
@@ -170,10 +173,11 @@ func (cb *ContextBuilder) buildContextInternal(query string, maxLinesDefault int
 	}
 
 	candidateLimit := cb.candidateLimitForIntent(intent)
-	candidates := cb.multiStrategySearch(query, candidateLimit, intent, trace, qEmb)
+	// Passes budget weights so multiStrategySearch uses the same allocation
+	candidates := cb.multiStrategySearch(query, candidateLimit, intent, budget.StrategyWeights, trace, qEmb)
 	trace.TotalCandidates = len(candidates)
 	cb.debugLog.Log("Multi-strategy search: %d candidates", len(candidates))
-	// Merge anchors + callsite hits
+
 	candidates = mergeWithPriority(anchors, callSiteResults, candidates)
 	cb.debugLog.Log("After merge: %d candidates", len(candidates))
 
@@ -191,7 +195,6 @@ func (cb *ContextBuilder) buildContextInternal(query string, maxLinesDefault int
 		selected = cb.mmrSelect(expanded, budget.ContextBudget, qEmb, anchorFiles, trace, gate)
 	} else {
 		trace.SelectionMethod = "greedy"
-		// Apply gate before greedy selection — selectChunks has no gate awareness.
 		if gate.active {
 			filtered := make([]ScoredChunk, 0, len(expanded))
 			for _, sc := range expanded {
@@ -219,9 +222,10 @@ func (cb *ContextBuilder) buildContextInternal(query string, maxLinesDefault int
 		cb.hydrateContent(selected)
 		cb.debugLog.Log("Hydrated KB content for %d chunks", len(selected))
 	}
-	// Add actual source code (30% of budget)
-	sourceBudget := budget.ContextBudget * 65 / 100
-	selected = cb.hydrateSourceCode(selected, sourceBudget, maxLinesDefault)
+
+	// Source hydration gets the full remaining budget — applyBudget's
+	// bin-packing already handles fitting; no second discount needed.
+	selected = cb.hydrateSourceCode(selected, budget.ContextBudget, maxLinesDefault)
 
 	ctx := cb.assembleContext(selected)
 	trace.TotalTokens = ctx.TotalTokens
@@ -235,7 +239,6 @@ func (cb *ContextBuilder) buildContextInternal(query string, maxLinesDefault int
 	cb.mu.Lock()
 	cb.lastTrace = trace
 	cb.mu.Unlock()
-
 	return ctx, trace, nil
 }
 

--- a/internal/query/context_intent.go
+++ b/internal/query/context_intent.go
@@ -89,6 +89,7 @@ package query
 
 import (
 	"math"
+	"sort"
 	"strings"
 )
 
@@ -241,51 +242,98 @@ func (qi QueryIntent) Budget() map[string]float64 {
 }
 
 func (cb *ContextBuilder) allocateBudget(query string, intent QueryIntent) BudgetAllocation {
-	sysReserve := 150
-	qTokens := len(query) / 4
-	safetyBuf := 200
-	respReserve := 2000
 	total := cb.config.LLM.MaxTokens
-	ctxBudget := int(float64(total-qTokens-sysReserve-safetyBuf-respReserve) * 0.85)
 
-	w := map[string]float64{
-		"kb_exact": 0.30, "keyword": 0.25, "semantic": 0.25, "graph": 0.20,
+	// Token costs that eat into the model's context window
+	sysPromptTokens := 130           // buildSystemPrompt measure once and hardcode
+	qTokens := (len(query) / 4) + 10 // rough tiktoken estimate + small pad
+	respReserve := 2048              // room for the LLM to write its answer
+
+	// Single safety margin — don't double-penalize with both subtraction and *0.85
+	ctxBudget := total - sysPromptTokens - qTokens - respReserve
+	if ctxBudget < 512 {
+		ctxBudget = 512 // floor: always allow some context
 	}
 
+	// Strategy weights sum to 1.0 for each intent
+	// Needs to update weight after trial and error
+	type weights struct{ kbExact, keyword, semantic, graph float64 }
+	var ww weights
 	switch intent.Type {
 	case IntentCallers, IntentCallees:
-		// callsite scan is the primary signal — reduce semantic noise
-		w["kb_exact"], w["keyword"], w["semantic"], w["graph"] = 0.45, 0.30, 0.10, 0.15
+		ww = weights{0.45, 0.30, 0.10, 0.15}
 	case IntentSymbolExact:
-		w["kb_exact"], w["keyword"], w["semantic"], w["graph"] = 0.55, 0.20, 0.10, 0.15
+		ww = weights{0.55, 0.20, 0.10, 0.15}
 	case IntentSymbolFuzzy:
-		w["kb_exact"], w["keyword"], w["semantic"], w["graph"] = 0.40, 0.25, 0.20, 0.15
+		ww = weights{0.40, 0.25, 0.20, 0.15}
 	case IntentConcept:
-		w["kb_exact"], w["keyword"], w["semantic"], w["graph"] = 0.15, 0.20, 0.50, 0.15
+		ww = weights{0.15, 0.20, 0.50, 0.15}
 	case IntentFlow:
-		w["kb_exact"], w["keyword"], w["semantic"], w["graph"] = 0.20, 0.15, 0.25, 0.40
+		ww = weights{0.20, 0.15, 0.25, 0.40}
 	case IntentDebug:
-		w["kb_exact"], w["keyword"], w["semantic"], w["graph"] = 0.35, 0.35, 0.15, 0.15
+		ww = weights{0.35, 0.35, 0.15, 0.15}
+	default:
+		ww = weights{0.30, 0.25, 0.25, 0.20}
 	}
 
 	return BudgetAllocation{
 		MaxTokens:       total,
-		SystemReserve:   sysReserve,
+		SystemReserve:   sysPromptTokens,
 		QueryCost:       qTokens,
 		ResponseReserve: respReserve,
 		ContextBudget:   ctxBudget,
-		StrategyWeights: w,
+		StrategyWeights: map[string]float64{
+			"kb_exact": ww.kbExact,
+			"keyword":  ww.keyword,
+			"semantic": ww.semantic,
+			"graph":    ww.graph,
+		},
 	}
 }
 
 // applyBudget truncates a pre-sorted slice to fit within the token budget.
 func (cb *ContextBuilder) applyBudget(chunks []ScoredChunk, budget int) []ScoredChunk {
-	used := 0
-	for i, sc := range chunks {
-		used += sc.Chunk.Tokens
-		if used > budget {
-			return chunks[:i]
+	if len(chunks) == 0 || budget <= 0 {
+		return nil
+	}
+
+	included := make([]ScoredChunk, 0, len(chunks))
+	var skipped []ScoredChunk
+	remaining := budget
+
+	// Pass 1: greedy in score order
+	for _, sc := range chunks {
+		cost := sc.Chunk.Tokens
+		if cost <= 0 {
+			cost = 1 // guard against zero-token chunks causing infinite loops
+		}
+		if cost <= remaining {
+			included = append(included, sc)
+			remaining -= cost
+		} else {
+			skipped = append(skipped, sc)
 		}
 	}
-	return chunks
+
+	// Pass 2: bin-pack skipped chunks by ascending token cost
+	if remaining > 0 && len(skipped) > 0 {
+		sort.Slice(skipped, func(i, j int) bool {
+			return skipped[i].Chunk.Tokens < skipped[j].Chunk.Tokens
+		})
+		for _, sc := range skipped {
+			if remaining <= 0 {
+				break
+			}
+			cost := sc.Chunk.Tokens
+			if cost <= remaining {
+				included = append(included, sc)
+				remaining -= cost
+			}
+		}
+	}
+
+	cb.debugLog.Log("applyBudget: %d/%d chunks fit, %d tokens used of %d (%d remaining)",
+		len(included), len(chunks), budget-remaining, budget, remaining)
+
+	return included
 }

--- a/internal/query/context_kb.go
+++ b/internal/query/context_kb.go
@@ -191,6 +191,131 @@ func (cb *ContextBuilder) findChunkForLocation(loc string) *Chunk {
 	return nil
 }
 
+// Extractors
+func extractFnParts(fn types.KBFunction) fnParts {
+	calls := make([]callPart, len(fn.Calls))
+	for i, c := range fn.Calls {
+		calls[i] = callPart{callee: c.Callee, line: c.Line}
+	}
+	return fnParts{
+		name:      fn.Name,
+		signature: fn.Signature,
+		docstring: fn.Docstring,
+		lineStart: fn.LineStart,
+		lineEnd:   fn.LineEnd,
+		calls:     calls,
+	}
+}
+
+func extractClassParts(cls types.KBClass) classParts {
+	methods := make([]methodPart, len(cls.Methods))
+	for i, m := range cls.Methods {
+		methods[i] = methodPart{name: m.Name, lineStart: m.LineStart, lineEnd: m.LineEnd}
+	}
+	return classParts{
+		name:      cls.Name,
+		docstring: cls.Docstring,
+		lineStart: cls.LineStart,
+		lineEnd:   cls.LineEnd,
+		methods:   methods,
+	}
+}
+
+// Content builders (mirror buildChunkFromKBFunction/Class exactly)
+
+func (cb *ContextBuilder) buildChunkFromParts(p fnParts, filePath string) Chunk {
+	content := fmt.Sprintf("Function: %s\nSignature: %s\nLines: %d-%d\n",
+		p.name, p.signature, p.lineStart, p.lineEnd)
+	if p.docstring != "" {
+		content += "Documentation: " + p.docstring + "\n"
+	}
+	if len(p.calls) > 0 {
+		content += "Calls:\n"
+		for _, c := range p.calls {
+			content += fmt.Sprintf("  - %s (line %d)\n", c.callee, c.line)
+		}
+	}
+	return Chunk{
+		ID:        fmt.Sprintf("%s:%d-%d", filePath, p.lineStart, p.lineEnd),
+		ChunkType: "function", File: filePath,
+		StartLine: p.lineStart, EndLine: p.lineEnd,
+		Content: content, Tokens: len(content) / 4,
+		Symbols: []string{p.name}, Name: p.name, Importance: 0.9,
+	}
+}
+
+func (cb *ContextBuilder) buildClassFromParts(p classParts, filePath string) Chunk {
+	content := fmt.Sprintf("Class: %s\nLines: %d-%d\n", p.name, p.lineStart, p.lineEnd)
+	if p.docstring != "" {
+		content += "Documentation: " + p.docstring + "\n"
+	}
+	if len(p.methods) > 0 {
+		content += "Methods:\n"
+		for _, m := range p.methods {
+			content += fmt.Sprintf("  - %s (lines %d-%d)\n", m.name, m.lineStart, m.lineEnd)
+		}
+	}
+	syms := make([]string, 0, len(p.methods)+1)
+	syms = append(syms, p.name)
+	for _, m := range p.methods {
+		syms = append(syms, m.name)
+	}
+	return Chunk{
+		ID:        fmt.Sprintf("%s:%d-%d", filePath, p.lineStart, p.lineEnd),
+		ChunkType: "class", File: filePath,
+		StartLine: p.lineStart, EndLine: p.lineEnd,
+		Content: content, Tokens: len(content) / 4,
+		Symbols: syms, Name: p.name, Importance: 0.95,
+	}
+}
+
+// addChunksFromFile
+
+func (cb *ContextBuilder) addChunksFromFile(filePath string, fs *types.FileData) {
+	fileIdx := make(map[[2]int]func() string)
+
+	for _, fn := range fs.Functions {
+		c := cb.buildChunkFromKBFunction(fn, filePath)
+		if cb.lazyContent {
+			p := extractFnParts(fn) // cheap copy of only what we need
+			fp := filePath
+			fileIdx[[2]int{c.StartLine, c.EndLine}] = func() string {
+				return cb.buildChunkFromParts(p, fp).Content
+			}
+			c.Content = ""
+		}
+		cb.chunks = append(cb.chunks, c)
+	}
+
+	for _, cls := range fs.Classes {
+		cc := cb.buildChunkFromKBClass(cls, filePath)
+		if cb.lazyContent {
+			p := extractClassParts(cls)
+			fp := filePath
+			fileIdx[[2]int{cc.StartLine, cc.EndLine}] = func() string {
+				return cb.buildClassFromParts(p, fp).Content
+			}
+			cc.Content = ""
+		}
+		cb.chunks = append(cb.chunks, cc)
+
+		for _, m := range cls.Methods {
+			mc := cb.buildChunkFromKBFunction(m, filePath)
+			if cb.lazyContent {
+				p := extractFnParts(m)
+				fp := filePath
+				fileIdx[[2]int{mc.StartLine, mc.EndLine}] = func() string {
+					return cb.buildChunkFromParts(p, fp).Content
+				}
+				mc.Content = ""
+			}
+			cb.chunks = append(cb.chunks, mc)
+		}
+	}
+
+	cb.hydrateIdx[filePath] = fileIdx
+}
+
 // buildChunkFromKBFunction constructs a Chunk from a KBFunction (function or method).
 // Materializes signature, docstring, and call relationships into a human-readable
 // chunk with metadata for retrieval scoring.

--- a/internal/query/context_loader.go
+++ b/internal/query/context_loader.go
@@ -56,6 +56,7 @@ package query
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"math"
 	"os"
@@ -67,7 +68,7 @@ import (
 )
 
 const (
-	ivfBuildThreshold = 10_000
+	ivfBuildThreshold = 50_000
 	invIdxThreshold   = 5_000
 	lazyContentLimit  = 50_000
 	ivfNClusters      = 256
@@ -295,18 +296,58 @@ func (cb *ContextBuilder) loadChunksFromKB() error {
 	cb.hasKB = cb.kbData != nil
 	kb = types.KnowledgeBaseRef{}
 	runtime.GC()
+	cb.debugLog.Log("Freed kb.json memory, current heap: %d MB",
+		getHeapAlloc()/1024/1024)
+	return nil
+}
 
-	// Load call graph and build call site index
-	done = cb.logFileLoad("kb_call_graph.json")
-	var callGraph types.CallGraphRef
-	err = decodeJSONFile(filepath.Join(cb.eulixDir, "kb_call_graph.json"), &callGraph)
-	done(err)
+func (cb *ContextBuilder) streamKBChunks() error {
+	path := filepath.Join(cb.eulixDir, "kb.json")
+
+	r, cleanup, err := openForSequentialRead(path)
 	if err != nil {
-		return fmt.Errorf("kb_call_graph.json: %w", err)
+		return err
+	}
+	defer cleanup()
+
+	// encoding/json required here: sonic's decoder doesn't implement
+	// Token()/More() streaming use stdlib for the token walk.
+	dec := json.NewDecoder(r)
+
+	if err := jsonSkipToKey(dec, "structure"); err != nil {
+		return fmt.Errorf("finding 'structure' key: %w", err)
+	}
+	if _, err := dec.Token(); err != nil {
+		return fmt.Errorf("reading structure opening brace: %w", err)
 	}
 
-	cb.callSites = buildCallSiteIndexFromGraph(&callGraph, cb.chunks)
-	cb.debugLog.Log("Built call-site index with %d entries", len(cb.callSites))
+	cb.chunks = make([]Chunk, 0, 320_000)
+	cb.hydrateIdx = make(map[string]map[[2]int]func() string, 40_000)
+
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			return fmt.Errorf("reading file path token: %w", err)
+		}
+		filePath, ok := tok.(string)
+		if !ok {
+			return fmt.Errorf("expected string key, got %T", tok)
+		}
+
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			return fmt.Errorf("reading FileData for %s: %w", filePath, err)
+		}
+
+		var fs types.FileData
+		if err := sonicCopy.Unmarshal(raw, &fs); err != nil {
+			return fmt.Errorf("unmarshaling FileData for %s: %w", filePath, err)
+		}
+
+		cb.addChunksFromFile(filePath, &fs)
+	}
+
+	cb.lazyContent = len(cb.chunks) > lazyContentLimit
 	return nil
 }
 
@@ -430,7 +471,14 @@ func (cb *ContextBuilder) loadEmbeddings() error {
 
 	// Build IVF index if needed
 	if numEmb > ivfBuildThreshold {
-		cb.ivfIndex = buildIVFIndex(cb.embeddings, ivfNClusters, ivfKMeansIter)
+		go func() {
+			idx := buildIVFIndex(cb.embeddings, ivfNClusters, ivfKMeansIter)
+			cb.mu.Lock()
+			cb.ivfIndex = idx
+			cb.mu.Unlock()
+			cb.debugLog.Log("IVF index built: %d clusters", ivfNClusters)
+		}()
+		cb.debugLog.Log("IVF build started in background (%d embeddings)", numEmb)
 	}
 	return nil
 }
@@ -485,37 +533,79 @@ func (cb *ContextBuilder) loadVectorMap() error {
 	if err != nil {
 		return fmt.Errorf("vectors.bin not found: %w", err)
 	}
-	if len(data) < 12 {
-		return fmt.Errorf("invalid vectors.bin: too short (%d bytes)", len(data))
+
+	const minHeader = 4 + 4 + 4 + 1 + 4 // magic+version+model_len_prefix+1char+count
+	if len(data) < minHeader {
+		return fmt.Errorf("vectors.bin too short: %d bytes", len(data))
 	}
+
 	off := 0
+
+	// Magic
 	if string(data[off:off+4]) != MagicBytes {
 		return fmt.Errorf("wrong magic in vectors.bin: %q", data[off:off+4])
 	}
 	off += 4
+
+	// Version
 	version := binary.LittleEndian.Uint32(data[off : off+4])
 	off += 4
+	cb.debugLog.Log("vectors.bin: version=%d (expected=%d)", version, BinaryVersion)
 	if version != BinaryVersion {
 		return fmt.Errorf("vectors.bin version mismatch: expected %d, got %d", BinaryVersion, version)
 	}
-	_, off, err = readStr(data, off)
-	if err != nil {
-		return fmt.Errorf("reading model name: %w", err)
-	}
+
+	// Model name — validate the length prefix before reading
 	if off+4 > len(data) {
-		return fmt.Errorf("invalid vectors.bin: truncated header")
+		return fmt.Errorf("vectors.bin: truncated before model name length")
+	}
+	modelNameLen := int(binary.LittleEndian.Uint32(data[off : off+4]))
+	cb.debugLog.Log("vectors.bin: model name length=%d", modelNameLen)
+	if modelNameLen > 512 {
+		return fmt.Errorf("vectors.bin: model name length=%d is implausible, file may be corrupt (off=%d)", modelNameLen, off)
+	}
+	off += 4
+	if off+modelNameLen > len(data) {
+		return fmt.Errorf("vectors.bin: truncated reading model name (need %d bytes at off=%d, have %d)", modelNameLen, off, len(data))
+	}
+	modelName := string(data[off : off+modelNameLen])
+	off += modelNameLen
+	cb.debugLog.Log("vectors.bin: model=%q", modelName)
+
+	// Count
+	if off+4 > len(data) {
+		return fmt.Errorf("vectors.bin: truncated before count field")
 	}
 	count := int(binary.LittleEndian.Uint32(data[off : off+4]))
 	off += 4
+	cb.debugLog.Log("vectors.bin: count=%d, bytes remaining=%d", count, len(data)-off)
+
+	// Sanity: each entry is at minimum 4 (len prefix) + 1 (id char) = 5 bytes
+	if count > (len(data)-off)/5 {
+		return fmt.Errorf("vectors.bin: count=%d impossible given %d bytes remaining, file is corrupt", count, len(data)-off)
+	}
+	if count > 10_000_000 {
+		return fmt.Errorf("vectors.bin: count=%d exceeds sanity limit", count)
+	}
+
 	cb.vectorMap = make(map[string]int, count)
 	for i := 0; i < count; i++ {
-		var id string
-		id, off, err = readStr(data, off)
-		if err != nil {
-			return fmt.Errorf("reading id at index %d: %w", i, err)
+		if off+4 > len(data) {
+			return fmt.Errorf("vectors.bin: truncated reading id length at index %d (off=%d)", i, off)
 		}
+		idLen := int(binary.LittleEndian.Uint32(data[off : off+4]))
+		off += 4
+		if idLen == 0 || idLen > 1024 {
+			return fmt.Errorf("vectors.bin: implausible id length=%d at index %d (off=%d)", idLen, i, off)
+		}
+		if off+idLen > len(data) {
+			return fmt.Errorf("vectors.bin: truncated reading id at index %d (need %d bytes, have %d)", i, idLen, len(data)-off)
+		}
+		id := string(data[off : off+idLen])
+		off += idLen
 		cb.vectorMap[id] = i
 	}
+
 	return nil
 }
 
@@ -528,29 +618,43 @@ func (cb *ContextBuilder) loadVectorMap() error {
 // the routing path; it returns the raw *CallGraph type rather than the
 // map[string][]Relationship representation built here. In Go a method and a
 // package-level function may share a name without conflict; both are intentional.
-//
-// See:
-//   - context_graph.go: expandGraph uses call graph to trace related code
-//   - context_search.go: integration with multi-strategy search pipeline
-func (cb *ContextBuilder) loadCallGraph() {
+func (cb *ContextBuilder) loadAndIndexCallGraph() {
 	done := cb.logFileLoad("kb_call_graph.json")
-	var gd CallGraphData
-	err := decodeJSONFile(filepath.Join(cb.eulixDir, "kb_call_graph.json"), &gd)
+	var cg types.CallGraphRef
+	err := decodeJSONFile(filepath.Join(cb.eulixDir, "kb_call_graph.json"), &cg)
 	done(err)
 	if err != nil {
 		cb.hasCallGraph = false
+		cb.debugLog.Log("Call graph not loaded: %v", err)
 		return
 	}
-	cb.callGraph = make(map[string][]Relationship, len(gd.Functions))
-	for fn, fd := range gd.Functions {
-		rels := make([]Relationship, 0, len(fd.Calls)+len(fd.CalledBy))
-		for _, c := range fd.Calls {
-			rels = append(rels, Relationship{Type: "calls", Target: c, Distance: 1})
-		}
-		for _, c := range fd.CalledBy {
-			rels = append(rels, Relationship{Type: "called_by", Target: c, Distance: 1})
-		}
-		cb.callGraph[fn] = rels
+
+	// log a sample to verify format alignment
+	if len(cg.Edges) > 0 {
+		cb.debugLog.Log("Call graph: %d nodes, %d edges", len(cg.Nodes), len(cg.Edges))
+		cb.debugLog.Log("Edge sample: from=%q to=%q type=%q",
+			cg.Edges[0].From, cg.Edges[0].To, cg.Edges[0].EdgeType)
 	}
+	if len(cb.chunks) > 0 {
+		cb.debugLog.Log("Chunk sample: id=%q name=%q class=%q symbols=%v",
+			cb.chunks[0].ID, cb.chunks[0].Name, cb.chunks[0].ClassName, cb.chunks[0].Symbols)
+	}
+
+	// Build cb.callGraph (used by call graph expansion during retrieval)
+	cb.callGraph = make(map[string][]Relationship, len(cg.Nodes))
+	for _, e := range cg.Edges {
+		if e.EdgeType != "call" {
+			continue
+		}
+		cb.callGraph[e.From] = append(cb.callGraph[e.From],
+			Relationship{Type: "calls", Target: e.To, Distance: 1})
+		cb.callGraph[e.To] = append(cb.callGraph[e.To],
+			Relationship{Type: "called_by", Target: e.From, Distance: 1})
+	}
+
+	// Build cb.callSites (used by call-site expansion during retrieval)
+	cb.callSites = buildCallSiteIndex(&cg, cb.chunks)
 	cb.hasCallGraph = len(cb.callGraph) > 0
+	cb.debugLog.Log("Call graph indexed: %d relationships, %d call sites",
+		len(cb.callGraph), len(cb.callSites))
 }

--- a/internal/query/context_search.go
+++ b/internal/query/context_search.go
@@ -126,16 +126,23 @@ type ExplicitAnchor struct {
 //   - vectorSearchIVF / vectorSearch: Semantic vector search
 //   - context_intent.go: QueryIntent and budget allocation
 func (cb *ContextBuilder) multiStrategySearch(
-	query string, topK int, intent QueryIntent, trace *DebugTrace, qEmb []float32,
+	query string,
+	topK int,
+	intent QueryIntent,
+	weights map[string]float64,
+	trace *DebugTrace,
+	qEmb []float32,
 ) []ScoredChunk {
 	all := make(map[string]ScoredChunk, topK*2)
-
 	anchors := extractExplicitAnchors(query)
 	gate := buildPathGate(anchors)
+
 	if len(anchors) > 0 {
-		cb.debugLog.Log("Explicit anchors: %d, gate active: %v (required: %v)", len(anchors), gate.active, gate.required)
+		cb.debugLog.Log("Explicit anchors: %d, gate active: %v (required: %v)",
+			len(anchors), gate.active, gate.required)
 		for _, a := range anchors {
-			cb.debugLog.Log("  anchor: file=%q func=%q line=%q score=%.0f", a.File, a.FuncName, a.Line, a.Score)
+			cb.debugLog.Log("  anchor: file=%q func=%q line=%q score=%.0f",
+				a.File, a.FuncName, a.Line, a.Score)
 		}
 		anchorsHits := cb.explicitAnchorSearch(anchors)
 		anchorsHits = gate.applyGate(anchorsHits)
@@ -153,6 +160,7 @@ func (cb *ContextBuilder) multiStrategySearch(
 			topK = highConfidence + 20
 		}
 	}
+
 	run := func(name string, fn func() []ScoredChunk, multiBoost float64) {
 		t0 := time.Now()
 		results := fn()
@@ -182,11 +190,11 @@ func (cb *ContextBuilder) multiStrategySearch(
 	if cb.hasKB {
 		run("kb_exact", func() []ScoredChunk { return cb.kbExactLookup(query, intent) }, 2.5)
 	}
-
 	run("exact", func() []ScoredChunk { return cb.exactSymbolSearch(query) }, 2.0)
 	run("partial", func() []ScoredChunk { return cb.partialIdentifierMatch(query) }, 1.5)
 
-	kwTopK := int(float64(topK) * (0.4 + 0.3*intent.Budget()["keyword"]))
+	// Use weights from allocateBudget
+	kwTopK := int(float64(topK) * (0.3 + 0.4*weights["keyword"]))
 	syms := extractPotentialSymbols(query)
 	run("keyword", func() []ScoredChunk {
 		var res []ScoredChunk
@@ -209,7 +217,6 @@ func (cb *ContextBuilder) multiStrategySearch(
 					break
 				}
 			}
-			// Penalise _sym* matches
 			for _, sym := range syms {
 				if strings.HasPrefix(strings.ToLower(res[i].Name), "_"+strings.ToLower(sym)) {
 					res[i].Score -= 10.0
@@ -222,11 +229,9 @@ func (cb *ContextBuilder) multiStrategySearch(
 	skipSemantic := intent.Type == IntentCallers ||
 		intent.Type == IntentCallees ||
 		intent.Specificity > 0.85
-
 	if cb.hasEmbeddings && !skipSemantic && qEmb != nil {
-		semTopK := int(float64(topK) * (0.3 + 0.3*intent.Budget()["semantic"]))
+		semTopK := int(float64(topK) * (0.2 + 0.5*weights["semantic"]))
 		run("semantic", func() []ScoredChunk {
-			// qEmb already computed — no EmbedQueryBinary call here
 			var raw []ScoredChunk
 			if cb.ivfIndex != nil {
 				raw = cb.vectorSearchIVF(qEmb, semTopK, 0.5)
@@ -245,6 +250,20 @@ func (cb *ContextBuilder) multiStrategySearch(
 		result = append(result, sc)
 	}
 	boostBySubsystemPath(result, query)
+	// In multiStrategySearch, after boostBySubsystemPath:
+	for i := range result {
+		f := result[i].File
+		if strings.Contains(f, "/tests/") ||
+			strings.Contains(f, "/test_") ||
+			strings.Contains(f, "fake_") ||
+			strings.Contains(f, "_test.go") {
+			// Don't zero out — tests are valid for debug/callee queries
+			// Just de-prioritize for concept/overview queries
+			if intent.Type == IntentConcept || intent.Type == IntentFlow {
+				result[i].Score *= 0.4
+			}
+		}
+	}
 	sort.Slice(result, func(i, j int) bool {
 		if result[i].MatchType == "exact" && result[j].MatchType != "exact" {
 			return true
@@ -673,36 +692,50 @@ func (cb *ContextBuilder) invertedKeywordSearchBM25(query string, topK int) []Sc
 //   - isIdentRune: Character predicate for identifier matching
 //   - context_graph.go: expandGraph uses this index for caller/callee expansion
 //   - context_loader.go: Called during KB loading
-func buildCallSiteIndex(chunks []Chunk) callSiteIndex {
-	idx := make(callSiteIndex, 512)
-
-	for i, chunk := range chunks {
-		content := chunk.Content
-		if content == "" {
-			continue
-		}
-
-		for j := 0; j < len(content); {
-			paren := strings.IndexByte(content[j:], '(')
-			if paren < 0 {
-				break
-			}
-			paren += j
-
-			start := paren - 1
-			for start >= 0 && isIdentRune(content[start]) {
-				start--
-			}
-			start++
-
-			if start < paren {
-				sym := strings.ToLower(content[start:paren])
-				idx[sym] = append(idx[sym], i)
-			}
-			j = paren + 1
+func buildCallSiteIndex(cg *types.CallGraphRef, chunks []Chunk) callSiteIndex {
+	// primary lookup: symbol stored in chunk.Symbols
+	symToChunks := make(map[string][]int, len(chunks))
+	for i, c := range chunks {
+		for _, sym := range c.Symbols {
+			symToChunks[sym] = append(symToChunks[sym], i)
 		}
 	}
-	return idx
+
+	// fallback lookup: derive the call-graph-style ID from chunk fields
+	nameToChunks := make(map[string][]int, len(chunks))
+	for i, c := range chunks {
+		key := normalizeToCallGraphID(c)
+		nameToChunks[key] = append(nameToChunks[key], i) // was nameToChunks[i]
+	}
+
+	callSites := make(callSiteIndex)
+	var missed int
+	for _, edge := range cg.Edges {
+		if edge.EdgeType != "call" {
+			continue
+		}
+		callerChunks, ok := symToChunks[edge.From]
+		if !ok {
+			callerChunks = nameToChunks[edge.From]
+		}
+		if len(callerChunks) == 0 {
+			missed++
+			continue
+		}
+		callSites[edge.To] = append(callSites[edge.To], callerChunks...)
+	}
+	return callSites
+}
+
+// normalizeToCallGraphID derives the call-graph node ID format from a chunk.
+// Mirrors what eulix-parser writes: "method_ClassName_funcName" or "func_funcName"
+func normalizeToCallGraphID(c Chunk) string {
+	name := strings.ToLower(strings.ReplaceAll(c.Name, " ", "_"))
+	if c.ClassName != "" {
+		class := strings.ToLower(strings.ReplaceAll(c.ClassName, " ", "_"))
+		return "method_" + class + "_" + name
+	}
+	return "func_" + name
 }
 
 func buildCallSiteIndexFromGraph(graph *types.CallGraphRef, chunks []Chunk) callSiteIndex {
@@ -756,6 +789,20 @@ func buildCallSiteIndexFromGraph(graph *types.CallGraphRef, chunks []Chunk) call
 	return idx
 }
 
+func buildRelationshipMap(cg *types.CallGraphRef) map[string][]Relationship {
+	m := make(map[string][]Relationship, len(cg.Nodes))
+	for _, e := range cg.Edges {
+		if e.EdgeType == "calls" {
+			m[e.From] = append(m[e.From], Relationship{
+				Type: "calls", Target: e.To, Distance: 1,
+			})
+			m[e.To] = append(m[e.To], Relationship{
+				Type: "called_by", Target: e.From, Distance: 1,
+			})
+		}
+	}
+	return m
+}
 func findChunkForLine(chunks []Chunk, chunkIdxs []int, line int) int {
 	if line == 0 {
 		return chunkIdxs[0] // no line info, fall back to first chunk in file

--- a/internal/query/context_utils.go
+++ b/internal/query/context_utils.go
@@ -51,11 +51,13 @@ package query
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"eulix/internal/types"
 	"fmt"
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 	"unicode"
@@ -73,6 +75,12 @@ func (cb *ContextBuilder) Close() error { return nil }
 //   - buildCallSiteIndex: Uses this to recognize identifier boundaries
 func isIdentRune(b byte) bool {
 	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
+func getHeapAlloc() uint64 {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return m.HeapAlloc
 }
 
 // GetLastTrace returns the most recent DebugTrace from the last query execution.
@@ -106,12 +114,33 @@ func (cb *ContextBuilder) writeContextToFile(ctx *types.ContextWindow) error {
 	return err
 }
 
+func jsonSkipToKey(dec *json.Decoder, target string) error {
+	// Consume the opening '{' of the top-level object
+	if _, err := dec.Token(); err != nil {
+		return err
+	}
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		key, ok := tok.(string)
+		if !ok {
+			return fmt.Errorf("expected string key, got %T", tok)
+		}
+		if key == target {
+			return nil // dec is now positioned just before the value
+		}
+		var skip json.RawMessage
+		if err := dec.Decode(&skip); err != nil {
+			return fmt.Errorf("skipping key %q: %w", key, err)
+		}
+	}
+	return fmt.Errorf("key %q not found", target)
+}
+
 // NewDebugLogger creates a thread-safe debug logger writing to eulixDir/context_debug.log.
 // If file creation fails, returns a silent (no-op) logger rather than panicking.
-//
-// See:
-//   - DebugLogger.Log: Timestamp-prefixed logging
-//   - DebugLogger.Close: Should be called in context_builder cleanup
 func NewDebugLogger(eulixDir string) *DebugLogger {
 	logPath := filepath.Join(eulixDir, "context_debug.log")
 	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)

--- a/internal/query/context_vectorIVF.go
+++ b/internal/query/context_vectorIVF.go
@@ -43,12 +43,16 @@ See:
 package query
 
 import (
-	"math"
+	"log"
 	"math/rand"
+	"runtime"
 	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
 )
 
-const ivfNProbe = 8
+const ivfNProbe = 32
 
 // vectorSearchIVF performs approximate nearest neighbor search using IVF clustering.
 // It finds topK chunks with similarity >= threshold by:
@@ -57,28 +61,37 @@ const ivfNProbe = 8
 // 3. Re-ranking candidates by exact cosine similarity
 // Falls back to brute-force search if IVF index is unavailable.
 func (cb *ContextBuilder) vectorSearchIVF(qEmb []float32, topK int, threshold float64) []ScoredChunk {
-	if cb.ivfIndex == nil {
+	// IVF may still be building in background — fall back to linear scan
+	cb.mu.Lock()
+	idx := cb.ivfIndex
+	cb.mu.Unlock()
+	if idx == nil {
 		return cb.vectorSearch(qEmb, topK, threshold)
 	}
-	idx := cb.ivfIndex
 
 	type centDist struct {
-		d float64
+		d float32
 		i int
 	}
+
+	// Rank centroids by similarity to query (cast to float32 to stay consistent
+	// with how centroids were built)
 	cd := make([]centDist, idx.NClusters)
 	for i, c := range idx.Centroids {
-		cd[i] = centDist{-cosineSimilarity(qEmb, c), i}
+		cd[i] = centDist{float32(cosineSimilarity(qEmb, c)), i}
 	}
-	sort.Slice(cd, func(i, j int) bool { return cd[i].d < cd[j].d })
+	// Sort descending by similarity (highest first)
+	sort.Slice(cd, func(i, j int) bool { return cd[i].d > cd[j].d })
 
 	nProbe := ivfNProbe
 	if nProbe > idx.NClusters {
 		nProbe = idx.NClusters
 	}
 
+	threshF := float32(threshold)
 	scored := make([]ScoredChunk, 0, topK*2)
-	seen := make(map[int32]bool, topK*2)
+	seen := make(map[int32]bool, topK*4)
+
 	for p := 0; p < nProbe; p++ {
 		for _, embIdx := range idx.Lists[cd[p].i] {
 			if seen[embIdx] {
@@ -88,11 +101,16 @@ func (cb *ContextBuilder) vectorSearchIVF(qEmb []float32, topK int, threshold fl
 			if int(embIdx) >= len(cb.chunks) || int(embIdx) >= len(cb.embeddings) {
 				continue
 			}
-			if sim := cosineSimilarity(qEmb, cb.embeddings[embIdx]); sim >= threshold {
-				scored = append(scored, ScoredChunk{Chunk: cb.chunks[embIdx], Score: sim})
+			sim := float32(cosineSimilarity(qEmb, cb.embeddings[embIdx]))
+			if sim >= threshF {
+				scored = append(scored, ScoredChunk{
+					Chunk: cb.chunks[embIdx],
+					Score: float64(sim),
+				})
 			}
 		}
 	}
+
 	sort.Slice(scored, func(i, j int) bool { return scored[i].Score > scored[j].Score })
 	if len(scored) > topK {
 		scored = scored[:topK]
@@ -124,8 +142,9 @@ func buildIVFIndex(embs [][]float32, k, maxIter int) *IVFIndex {
 		k = n
 	}
 	dim := len(embs[0])
-	rng := rand.New(rand.NewSource(42))
+	nWorkers := runtime.NumCPU()
 
+	rng := rand.New(rand.NewSource(42))
 	perm := rng.Perm(n)
 	centroids := make([][]float32, k)
 	for i := range centroids {
@@ -141,24 +160,56 @@ func buildIVFIndex(embs [][]float32, k, maxIter int) *IVFIndex {
 	}
 	counts := make([]int, k)
 
+	chunkSize := (n + nWorkers - 1) / nWorkers
+
 	for iter := 0; iter < maxIter; iter++ {
-		changed := 0
-		for ei, emb := range embs {
-			best, bestSim := int32(0), -math.MaxFloat64
-			for ci, c := range centroids {
-				if s := cosineSimilarity(emb, c); s > bestSim {
-					bestSim, best = s, int32(ci)
+		iterStart := time.Now()
+
+		// Parallel assignment: each worker owns a slice of vectors
+		var totalChanged int64
+		var wg sync.WaitGroup
+		for w := 0; w < nWorkers; w++ {
+			lo := w * chunkSize
+			hi := lo + chunkSize
+			if hi > n {
+				hi = n
+			}
+			wg.Add(1)
+			go func(lo, hi int) {
+				defer wg.Done()
+				var localChanged int64
+				for ei := lo; ei < hi; ei++ {
+					emb := embs[ei]
+					best := int32(0)
+					// reuse cosineSimilarity but track as float32 to avoid
+					// repeated float64 conversions in the hot path
+					bestSim := float32(-1e9)
+					for ci, c := range centroids {
+						// cosineSimilarity returns float64; cast once per call
+						s := float32(cosineSimilarity(emb, c))
+						if s > bestSim {
+							bestSim = s
+							best = int32(ci)
+						}
+					}
+					if assignments[ei] != best {
+						localChanged++
+						assignments[ei] = best
+					}
 				}
-			}
-			if assignments[ei] != best {
-				changed++
-			}
-			assignments[ei] = best
+				atomic.AddInt64(&totalChanged, localChanged)
+			}(lo, hi)
 		}
-		if changed == 0 {
+		wg.Wait()
+
+		log.Printf("[IVF] iter %d/%d: changed=%d elapsed=%v",
+			iter+1, maxIter, totalChanged, time.Since(iterStart))
+
+		if totalChanged == 0 {
 			break
 		}
 
+		// Serial centroid update — cheap relative to assignment
 		for i := range sums {
 			counts[i] = 0
 			for j := range sums[i] {
@@ -176,18 +227,24 @@ func buildIVFIndex(embs [][]float32, k, maxIter int) *IVFIndex {
 			if counts[ci] == 0 {
 				continue
 			}
+			inv := 1.0 / float64(counts[ci])
 			for j := range centroids[ci] {
-				centroids[ci][j] = float32(sums[ci][j] / float64(counts[ci]))
+				centroids[ci][j] = float32(sums[ci][j] * inv)
 			}
 		}
 	}
 
 	lists := make([][]int32, k)
 	for i := range lists {
-		lists[i] = make([]int32, 0)
+		lists[i] = make([]int32, 0, n/k+16)
 	}
 	for ei, ci := range assignments {
 		lists[ci] = append(lists[ci], int32(ei))
 	}
-	return &IVFIndex{Centroids: centroids, Lists: lists, NClusters: k, Dim: dim}
+	return &IVFIndex{
+		Centroids: centroids,
+		Lists:     lists,
+		NClusters: k,
+		Dim:       dim,
+	}
 }

--- a/internal/query/mmap_loaders.go
+++ b/internal/query/mmap_loaders.go
@@ -13,6 +13,7 @@ package query
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/bytedance/sonic"
@@ -85,4 +86,30 @@ func sizeOverflows(size int64) bool {
 // the current platform (only reachable on 32-bit builds).
 func errFileTooLarge(path string, size int64) error {
 	return fmt.Errorf("file %s is %d bytes, which overflows int on this platform", path, size)
+}
+
+// openForSequentialRead returns an io.Reader over path, using mmap with
+// MADV_SEQUENTIAL for large files where supported, and a buffered file
+// reader otherwise. The returned cleanup func must always be called
+// (even on error paths after a successful return) to release the
+// mapping/file.
+func openForSequentialRead(path string) (r io.Reader, cleanup func(), err error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	size := fi.Size()
+
+	if size >= mmapThreshold && !sizeOverflows(size) {
+		if r, cleanup, err := mmapForSequentialRead(path, size); err == nil {
+			return r, cleanup, nil
+		}
+		// mmap unsupported or failed — fall through to buffered reader.
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return bufio.NewReaderSize(f, jsonBufSize), func() { f.Close() }, nil
 }

--- a/internal/query/mmap_others.go
+++ b/internal/query/mmap_others.go
@@ -12,10 +12,23 @@ Prevents mmap to happen on unsupported os
 
 package query
 
-import "errors"
+import (
+	"bufio"
+	"errors"
+	"io"
+	"os"
+)
 
 var errNoMmap = errors.New("mmap not supported on this platform")
 
 func decodeViaMmap(_ string, _ int64, _ any) error {
 	return errNoMmap
+}
+
+func openForSequentialRead(path string) (io.Reader, func(), error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return bufio.NewReaderSize(f, jsonBufSize), func() { f.Close() }, nil
 }

--- a/internal/query/mmap_unix.go
+++ b/internal/query/mmap_unix.go
@@ -14,7 +14,9 @@ MADV_SEQUENTIAL for improved performance
 package query
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 
 	"golang.org/x/sys/unix"
@@ -58,4 +60,24 @@ func decodeViaMmap(path string, size int64, v any) error {
 	// Using sonic.ConfigDefault (CopyString: false) here would leave decoded
 	// string headers pointing into the now-unmapped region — use-after-free.
 	return sonicCopy.Unmarshal(data, v)
+}
+
+// mmapForSequentialRead mmaps path read-only and advises the kernel to
+// prefetch sequentially (MADV_SEQUENTIAL), matching JSON parse order.
+func mmapForSequentialRead(path string, size int64) (io.Reader, func(), error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mapped, err := unix.Mmap(int(f.Fd()), 0, int(size), unix.PROT_READ, unix.MAP_SHARED)
+	if err != nil {
+		f.Close()
+		return nil, nil, err
+	}
+
+	_ = unix.Madvise(mapped, unix.MADV_SEQUENTIAL)
+	f.Close() // mapping holds the pages; fd not needed after mmap
+
+	return bytes.NewReader(mapped), func() { _ = unix.Munmap(mapped) }, nil
 }

--- a/internal/query/mmap_windows.go
+++ b/internal/query/mmap_windows.go
@@ -15,6 +15,7 @@ package query
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"unsafe"
 
@@ -67,4 +68,10 @@ func decodeViaMmap(path string, size int64, v any) error {
 	// pointing into the unmapped region — use-after-free.
 	_ = sonic.ConfigDefault // referenced to keep the import visible in godoc
 	return sonicCopy.Unmarshal(data, v)
+}
+
+// mmapForSequentialRead is unavailable on non-unix platforms; callers
+// fall back to a buffered file reader.
+func mmapForSequentialRead(_ string, _ int64) (io.Reader, func(), error) {
+	return nil, nil, errNoMmap
 }

--- a/internal/query/router_handlers.go
+++ b/internal/query/router_handlers.go
@@ -19,7 +19,7 @@ import (
 // BuildPromptString composes header + task-specific body + footer.
 func BuildPromptString(query string, class *Classification, sourceAvailable bool, taskBody string) string {
 	return cotHeader(query, class, sourceAvailable) +
-		"=== TASK ===\n" +
+		" TASK \n" +
 		taskBody +
 		cotFooter()
 }
@@ -70,7 +70,7 @@ func cotHeader(query string, class *Classification, sourceAvailable bool) string
 
 // cotFooter appends a honesty reminder at the end of every prompt.
 func cotFooter() string {
-	return "\n=== HONESTY CONTRACT ===\n" +
+	return "\n HONESTY CONTRACT \n" +
 		"• Cite file + line range for every factual claim.\n" +
 		"• Write 'Not visible in context' rather than guessing.\n" +
 		"• Distinguish 'I see in source' from 'I infer from signature'.\n"

--- a/internal/types/context.go
+++ b/internal/types/context.go
@@ -13,6 +13,7 @@ type ContextChunk struct {
 	EndLine    int
 	Content    string
 	Importance float64
+	Tokens     int
 }
 
 // ContextWindow represents the full context for a query


### PR DESCRIPTION
Memory & I/O:
- streamKBChunks(): sequential JSON parsing, avoids loading entire kb.json
- addChunksFromFile(): per-file processing with lazy content hydration
- mmapForSequentialRead(): MADV_SEQUENTIAL for sequential prefetch
- loadVectorMap(): sanity checks for corrupt files

Retrieval:
- applyBudget(): two-pass (greedy + bin-packed leftovers)
- fillResidualBudget(): fit smallest skipped chunks into remaining tokens
- IVF index built asynchronously (non-blocking)
- ivfNProbe: 8 → 32 for better recall
- Parallel k-means assignment with atomic counters

Call Graph:
- loadAndIndexCallGraph() replaces loadCallGraph()
- Builds both callGraph and callSites from types.CallGraphRef
- normalizeToCallGraphID(): method_ClassName_funcName format

Prompt:
- buildSystemPrompt() separated from context prompt
- sysPromptTokens hardcoded at 130 (measured)
- Compact header: counts only, no explanatory boilerplate

Version: v0.6.8 → v0.6.9